### PR TITLE
Replace `navigator.language` with `navigator.languages[0]`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components
+*.iml

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-behavior",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "authors": [
     "Anonymous <anonymous@example.com>"
   ],

--- a/fs-behavior.html
+++ b/fs-behavior.html
@@ -35,7 +35,7 @@
           type: String,
           value: function() {
             if (window.FS && window.FS.simpleLocale) return FS.simpleLocale();
-            var lang = navigator.language;
+            var lang = navigator.languages[0];
             var matches = lang.match(/^\w{2}/);
             if (lang && matches) {
               return matches[0];

--- a/fs-behavior.html
+++ b/fs-behavior.html
@@ -10,6 +10,22 @@
       }
       return null;
     }
+
+    /**
+     * Gets the preferred language from the browser.
+     */
+    var getNavigatorLanguage = function() {
+      var navLang = navigator.language;
+
+      /* navigator.languages[0] is better, if it exists, because navigator.language is set
+       * to the OS language in Chrome. */
+      if (navigator.languages && navigator.languages.length > 0) {
+        navLang = navigator.languages[0];
+      }
+
+      return navLang;
+    };
+
     window.FSBehavior = {
       properties: {
         _base: {
@@ -35,7 +51,7 @@
           type: String,
           value: function() {
             if (window.FS && window.FS.simpleLocale) return FS.simpleLocale();
-            var lang = navigator.languages[0];
+            var lang = getNavigatorLanguage();
             var matches = lang.match(/^\w{2}/);
             if (lang && matches) {
               return matches[0];


### PR DESCRIPTION
### Changes
This is a Chrome only issue.

- Changed to use `navigator.languages[0]` to get the browser language instead of `navigator.language` because Chrome sets `navigator.language` to the OS language instead of the preferred language set by the user in the browser.